### PR TITLE
Add ability to remove formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 out
 dist
 node_modules
+package-lock.json
 .vscode-test/
 *.vsix

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,16 +2,46 @@ import * as vscode from 'vscode';
 
 // Generic function for text replacement and cursor position adjustment
 function formatText(editor: vscode.TextEditor, before: string, after: string = before) {
+	const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // Escape special characters
 	const selection = editor.selection;
-	const text = editor.document.getText(selection);
+	let deletedTextWithoutSelection = false;
 	editor.edit(editBuilder => {
-		if (selection.isEmpty) {
-			editBuilder.insert(selection.start, before + after);
-		} else {
-			editBuilder.replace(selection, before + text + after);
+        if (selection.isEmpty) {
+            // Get the position before and after the cursor
+            const cursorPosition = selection.start;
+            const beforeRange = new vscode.Range(cursorPosition.translate(0, -before.length), cursorPosition);
+            const afterRange = new vscode.Range(cursorPosition, cursorPosition.translate(0, after.length));
+
+            // Get the text before and after the cursor
+            const textBefore = editor.document.getText(beforeRange);
+            const textAfter = editor.document.getText(afterRange);
+
+            // Check if the before and after strings are already present
+            if (textBefore === before && textAfter === after) {
+                // Remove the before and after strings
+                editBuilder.delete(beforeRange);
+                editBuilder.delete(afterRange);
+				deletedTextWithoutSelection = true;		
+            } else {
+                // Add the before and after strings
+                editBuilder.insert(cursorPosition, before + after);
+            }
+        } else {
+			const selectedText = editor.document.getText(selection);
+			const beforePattern = new RegExp(`^${escapeRegExp(before)}`);
+			const afterPattern = new RegExp(`${escapeRegExp(after)}$`);
+		
+			if (beforePattern.test(selectedText) && afterPattern.test(selectedText)) {
+				// Remove before and after
+				const newText = selectedText.replace(beforePattern, '').replace(afterPattern, '');
+				editBuilder.replace(selection, newText);
+			} else {
+				// Add before and after
+				editBuilder.replace(selection, before + selectedText + after);
+			}
 		}
 	}).then(() => {
-		if (selection.isEmpty) {
+		if (selection.isEmpty && !deletedTextWithoutSelection) {
 			const newPosition = selection.start.translate(0, before.length);
 			editor.selection = new vscode.Selection(newPosition, newPosition);
 		}
@@ -103,13 +133,33 @@ export function activate(context: vscode.ExtensionContext) {
 			const document = editor.document;
 			const selection = editor.selection;
 			editor.edit(editorBuilder => {
+				let allStartWithDash = true;
+
 				for (let i = selection.start.line; i <= selection.end.line; i++) {
-					const line = document.lineAt(i)
-					editorBuilder.insert(line.range.start, '- ');
+					const line = document.lineAt(i);
+					const lineText = line.text;
+
+					if (!lineText.trimStart().startsWith('-')) {
+						allStartWithDash = false;
+						// Add the '-' if it doesn't exist
+						editorBuilder.insert(line.range.start, '- ');
+					} else if (!lineText.trimStart().startsWith('- ')) {
+						allStartWithDash = false;
+						// Add just a space
+						editorBuilder.insert(line.range.start.translate(0, 1), ' ');
+					}
 				}
-			})
+
+				if (allStartWithDash) {
+					for (let i = selection.start.line; i <= selection.end.line; i++) {
+						const line = document.lineAt(i);
+						const range = new vscode.Range(line.range.start, line.range.start.translate(0, 2)); // Remove the first 2 characters ("- ")
+						editorBuilder.delete(range);
+					}
+				}
+			});
 		}
-	})
+	});
 
 	// Add sortedList command
 	let sortedListListDisposable = vscode.commands.registerCommand('markdown-shortcut.sortedList', () => {
@@ -119,14 +169,36 @@ export function activate(context: vscode.ExtensionContext) {
 			const selection = editor.selection;
 			editor.edit(editBuilder => {
 				let lineNumber = 1;
+				let allStartWithNumber = true;
+
 				for (let i = selection.start.line; i <= selection.end.line; i++) {
 					const line = document.lineAt(i);
-					editBuilder.insert(line.range.start, `${ lineNumber }. ` );
+					const lineText = line.text;
+					if (!lineText.trimStart().startsWith(`${ lineNumber }.`)) {
+						allStartWithNumber = false;
+						// Add the number if it doesn't exist
+						editBuilder.insert(line.range.start, `${ lineNumber }. `);
+					}
+					else if (!lineText.trimStart().startsWith(`${ lineNumber }. `)) {
+						allStartWithNumber = false;
+						// Add just a space
+						let numberLength = lineNumber.toString().length;
+						editBuilder.insert(line.range.start.translate(0, numberLength + 1), ' ');
+					}
 					lineNumber++;
+				}
+
+				if (allStartWithNumber) {
+					for (let i = selection.start.line; i <= selection.end.line; i++) {
+						const line = document.lineAt(i);
+						let numberLength = lineNumber.toString().length;
+						const range = new vscode.Range(line.range.start, line.range.start.translate(0, numberLength + 2)); // Remove the number, period, and space ("1. ")
+						editBuilder.delete(range);
+					}
 				}
 			});
 		}
-	})
+	});
 
 	context.subscriptions.push(
 		boldDisposable,

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -66,4 +66,32 @@ suite('Extension Test Suite', () => {
         await testMarkdownCommand('markdown-shortcut.image', 'Hello', '![Hello](url)', 'Text should be formatted as an image link');
     });
 
+    test('Remove Bold Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.bold', '**Hello**', 'Hello', 'Text should not be bold');
+    });
+
+    test('Remove Italics Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.italics', '*Hello*', 'Hello', 'Text should not be italic');
+    });
+
+    test('Remove Underline Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.underline', '<u>Hello</u>', 'Hello', 'Text should not be underlined');
+    });
+
+    test('Remove Inline Code Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.code', '`Hello`', 'Hello', 'Text should not be formatted as inline code');
+    });
+
+    test('Remove Strikethrough Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.strikethrough', '~~Hello~~', 'Hello', 'Text should not be strikethrough');
+    });
+
+    test('Remove Hyperlink Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.hyperlink', '[Hello](url)', 'Hello', 'Text should not be formatted as a hyperlink');
+    });
+
+    test('Remove Image Command Test', async () => {
+        await testMarkdownCommand('markdown-shortcut.image', '![Hello](url)', 'Hello', 'Text should not be formatted as an image link');
+    });
+
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,11 +4,13 @@
 		"target": "ES2022",
 		"outDir": "out",
 		"lib": [
-			"ES2022"
+			"ES2022", "dom"
 		],
 		"sourceMap": true,
 		"rootDir": "src",
-		"strict": true   /* enable all strict type-checking options */
+		"strict": true,   /* enable all strict type-checking options */
+		"types": ["vscode", "mocha", "node"], 
+		"skipLibCheck": true, /* Skip type checking of declaration files. */
 		/* Additional Checks */
 		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
 		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Added logic to remove formatting from text.  With "Hello" selected, pressing Ctrl+B would bold it ("**Hello**") but you couldn't unbold the text.  Now pressing Ctrl+B with "**Hello**" selected will remove the bold formatting ("Hello").  This works both with and without a selection. 

This works for ordered and unordered lists as well.  However, it gets tricky for lists where some lines had a bullet or number and others did not. I followed Microsoft Word's behavior in this case.  When there is a mix of bullets/non-bulleted or numbered/non-numbered lines then applying the command will first apply bullets/numbers to all line and then applying the command again will remove the bullets/numbers.  