### PR TITLE
Improved hyperlink and image by selecting "url" after formatting text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,8 @@
 ### Fixed
 - Special character handling in text formatting with proper regex escaping
 - Cursor position is now correctly maintained when toggling formats
+
+## [0.0.6] - 2025-04-26
+
+### Improved
+- The "url" text is automatically selected after text is converted to a hyperlink or image 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-quick-shortcuts",
   "displayName": "Markdown Quick Shortcuts",
   "description": "A collection of quick shortcuts for Markdown editing in VS Code",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "engines": {
     "vscode": "^1.85.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,22 @@ function formatText(editor: vscode.TextEditor, before: string, after: string = b
 			const newPosition = selection.start.translate(0, before.length);
 			editor.selection = new vscode.Selection(newPosition, newPosition);
 		}
+		// If the selection is not empty and after includes "url" select the "url" after inserting the markdown
+		else if (!selection.isEmpty && after.includes("url")) {
+			// Calculate the new selection after the formatted text has been inserted
+			const newRange = new vscode.Range(
+				selection.start,
+				selection.start.translate(0, before.length + editor.document.getText(selection).length + after.length)
+			);
+			const newSelection = editor.document.getText(newRange);
+		
+			// Find "url" in the new selection and then select it
+			const urlIndex = newSelection.indexOf("url");
+			if (urlIndex !== -1) {
+				const newPosition = selection.start.translate(0, urlIndex);
+				editor.selection = new vscode.Selection(newPosition, newPosition.translate(0, 3));
+			}	
+		}
 	});
 }
 


### PR DESCRIPTION
To make it faster to enter hyperlinks and images, if you start with a selection and turn it into a hyperlink or image, it will select the word "url" after (and then you can just start typing the url or paste a url from the clipboard). 